### PR TITLE
Small update to MGA-DSM User Guide and optimization example

### DIFF
--- a/docs/source/_src_getting_started/_src_examples/mga_dsm_examples/mga_dsm_analysis.rst
+++ b/docs/source/_src_getting_started/_src_examples/mga_dsm_examples/mga_dsm_analysis.rst
@@ -30,10 +30,10 @@ Setup and inputs
 
 A simplified system of bodies suffices for this application, with the Sun as central body. The planets that are visited
 for a GA are defined in the list ``transfer_body_order``. The departure and arrival orbit can be specified, but don't
-necessarily need to be. By default, a transfer trajectory departs from / arrives at the edge of the SOI of the corresponding bodies
-(i.e. :math:`a = \infty`,  :math:`e=0`). In this example, the spacecraft departs from the edge of Earth's SOI and is
-inserted into a highly elliptical orbit around Saturn. We can specify *not* using DSMs by using the unpowered and unperturbed
-leg type.
+necessarily need to be. If not specified, the departure and arrival planets are considered swing-by nodes. Specifying
+:math:`a = \infty` and :math:`e=0` defines departure from / arrival at the edge of the SOI of the corresponding bodies.
+In this example, the spacecraft departs from the edge of Earth's SOI and is inserted into a highly elliptical orbit
+around Saturn. We can specify *not* using DSMs by using the unpowered and unperturbed leg type.
 
 .. code-block:: python
 

--- a/docs/source/_src_getting_started/_src_examples/mga_dsm_examples/mga_dsm_optimization.rst
+++ b/docs/source/_src_getting_started/_src_examples/mga_dsm_examples/mga_dsm_optimization.rst
@@ -8,7 +8,12 @@ In the following section, an example of the optimization of MGA-DSM trajectories
 optimizations within Tudat(py) and/or `Pygmo`_, please visit :ref:`pygmo_basics` first. The optimizer will search for
 transfer parameters that yield optimal solutions in terms of two objectives: :math:`\Delta V` and time of flight.
 
+The full code for this example was developed for the Collaborative Design Lab (CDL) and can be found in the
+`Download section`_ of the `CDL website`_.
+
 .. _`Pygmo`: https://esa.github.io/pygmo2/index.html
+.. _`Download section`: https://cdl-docs.readthedocs.io/en/latest/_src_downloads/downloads.html
+.. _`CDL website`: https://cdl-docs.readthedocs.io/en/latest/index.html
 
 Problem settings
 -------------------------------------------------

--- a/docs/source/_src_user_guide/astrodynamics/trajectory_design.rst
+++ b/docs/source/_src_user_guide/astrodynamics/trajectory_design.rst
@@ -60,10 +60,11 @@ retrieved from the module directly:
     dsm_velocity_based_leg_type = transfer_trajectory.dsm_velocity_based_leg_type
     dsm_position_based_leg_type = transfer_trajectory.dsm_position_based_leg_type
 
-
-The departure and arrival orbit characteristics are optional inputs. By default it is assumed :math:`a = \infty` and
-:math:`e=0`, which means that the spacecraft departs from / arrives at the edge of the SOI of the
-departure / arrival planet.
+The departure and arrival orbit characteristics are optional inputs. By default, Tudat(Py) assumes that :math:`a` and
+:math:`e` are ``NaN``, in which case the departure / arrival planets are analysed as swing-by nodes instead of departure
+/ arrival nodes. This is useful when combining multiple types of trajectories into one or when a mission's objective
+is to do a fly-by of the final target. Defining :math:`a=\infty` defines the departure / arrival orbit at the SOI of the
+corresponding body.
 
 Besides the general inputs, trajectory specific inputs are required, which are called transfer parameters. Which
 transfer parameters need to be defined, depends on the leg type. For all trajectories, *with* and *without* DSMs, it is
@@ -114,6 +115,11 @@ presents the additional parameters, so called leg and node free parameters, requ
 +---------------------------------------+-----------------------+-------------------------------------------------------+------------------------------------------------------------------------------+
 |                                       |                       | Magnitude of :math:`\Delta V` applied at periapsis    |                                                                              |
 +---------------------------------------+-----------------------+-------------------------------------------------------+------------------------------------------------------------------------------+
+
+In case the default departure / arrival orbit characteristics are used, such that these are considered swing-by nodes,
+the transfer parameters change accordingly. For a transfer *without* DSMs, an extra set of swing-by node parameters
+is included for the final node. For a transfer *with* DSMs, the departure node parameters will change into swing-by node
+parameters and an extra set of swing-by node parameters is included for the final node.
 
 
 General procedure


### PR DESCRIPTION
Updated the description for the defaults of the departure/arrival orbit characteristics. If not specified, the departure/arrival nodes are considered swingby nodes.

Added link to the CDL documentation in the optimization example, as the full code can be found there.
