### PR TITLE
Restructure element type section, minor fixes

### DIFF
--- a/docs/source/_src_user_guide/state_propagation/environment_setup/available_state_definitions_conversions.rst
+++ b/docs/source/_src_user_guide/state_propagation/environment_setup/available_state_definitions_conversions.rst
@@ -17,7 +17,7 @@ The various frame types of frame origins used in the Tudat simulation framework 
 Here, we briefly outline how to manually convert states between frame origins. In Tudat, each body automatically defines a frame origin,
 which is located at a predefined point in (or in exotic cases, outside), the body. Typically, the frame origin will coincide with the
 center of mass of the body for natural bodies. However, in case (for instance) the body possesses a spherical harmonic gravity field
-with non-zero degree 1 coefficients, the gravity field -which determines the internal mass distribution- can define an offset between
+with non-zero degree 1 coefficients, the gravity field (which determines the internal mass distribution) can define an offset between
 the origin of the body-centered frame, and its center-of-mass.
 
 When retrieving the state from a ``Body`` :ref:`during the propagation <translational_state_during_propagation>`, this state is
@@ -80,11 +80,9 @@ The time-derivative of the rotation matrix may be equivalently represented by th
 which we take to represent the angular velocity of frame :math:`A`, w.r.t. frame :math:`B`, expressed with frame orientation :math:`A`.
 For the typical case where :math:`B` is an inertial frame, :math:`\boldsymbol{\omega}_{BA}(=\boldsymbol{\omega}_{A})` is simply the angular
 velocity of :math:`A` (w.r.t. inertial space), represented in the frame fixed to body :math:`A` (TODO: link to propagation).
-More information is provided in the `Tudat mathematical model pdf <https://github.com/tudat-team/tudat-space/raw/master/Tudat_mathematical_model_definition.pdf>`_
+More information is provided in the `Tudat mathematical model pdf <https://github.com/tudat-team/tudat-space/raw/master/Tudat_mathematical_model_definition.pdf>`_.
 
 Manually, the above transformations would be done simply as:
-
-Manually, the state may then be transformed as:
 
 .. code-block:: python
 
@@ -92,24 +90,24 @@ Manually, the state may then be transformed as:
         time_derivative_of_rotation_to_frame  = ... # 3D Matrix
         original_state = ... # 6D Vector
 
-        rotated_state = np.zeros(6, dtype=float);
-        rotated_state[ :3] = rotation_to_frame * original_state[ :3 ];
-        rotated_state[3: ] = rotation_to_frame * original_state[ 3: ] + time_derivative_of_rotation_to_frame * original_state[ :3 ];
+        rotated_state = np.zeros(6, dtype=float)
+        rotated_state[ :3] = rotation_to_frame @ original_state[ :3 ]
+        rotated_state[3: ] = rotation_to_frame @ original_state[ 3: ] + time_derivative_of_rotation_to_frame @ original_state[ :3 ]
 
 Where the rotation matrix and its derivative (for body-fixed to inertial frames) can be obtained from the ``Body`` object during propagation, or a ``RotationalEphemeris``
 object outside of the propagation, see :ref:`below <body_fixed_frames>` for more details.
 
-Below, we give an overview of the available frames, and frame transformations, in Tudat, and discuss how they can be accessed both during
+Below, we give an overview of the available frames, and frame transformations in Tudat, and discuss how they can be accessed both during
 (when setting up a :ref:`custom model <custom_models>`), and outside of a propagation. The available frames are:
 
-  * :ref:`body_fixed_frames` Each ``Body`` in Tudat can have a fixed frame assigned to it (see `API documentation <https://py.api.tudat.space/en/latest/rotation_model.html#functions>`_ for a list of options for model types)
-  * :ref:`gcrs_itrs_frames` The high-accuracy rotation from GCRS to ITRS is implemented in Tudat. The ITRS, TIRS, CIRS and ICRS frames are defined
-  * :ref:`aero_frames` A number of frames typically used in entry and ascent trajectories: the Vertical, Trajectory and Aerodynamic frames
-  * :ref:`orbital_frames` The TNW and RSW frames (defined by the current relative translational state)
-  * :ref:`spice_frames` Any frame defined by the currently loaded Spice kernels can be accessed
-  * :ref:`predefined_orientations` The J2000 and ECLIPJ2000 frame orientations (at present, the only two supported options for the global frame orientation)
-  * :ref:`topocentric_frames` Each ground station/lander on a body has a frame (East-North-Up) automatically associated with it
-  * :ref:`additional_frames` The TEME, (TODO) frame
+  * :ref:`body_fixed_frames`: Each ``Body`` in Tudat can have a fixed frame assigned to it (see `API documentation <https://py.api.tudat.space/en/latest/rotation_model.html#functions>`_ for a list of options for model types).
+  * :ref:`gcrs_itrs_frames`: The high-accuracy rotation from GCRS to ITRS is implemented in Tudat. The ITRS, TIRS, CIRS and ICRS frames are defined.
+  * :ref:`aero_frames`: A number of frames typically used in entry and ascent trajectories: the Vertical, Trajectory and Aerodynamic frames.
+  * :ref:`orbital_frames`: The TNW and RSW frames (defined by the current relative translational state).
+  * :ref:`spice_frames`: Any frame defined by the currently loaded SPICE kernels can be accessed.
+  * :ref:`predefined_orientations`: The J2000 and ECLIPJ2000 frame orientations (at present, the only two supported options for the global frame orientation).
+  * :ref:`topocentric_frames`: Each ground station/lander on a body has a frame (East-North-Up) automatically associated with it.
+  * :ref:`additional_frames`: The TEME frame, which is typically used for the definition of two-line elements (TLE).
 
 .. _body_fixed_frames:
 
@@ -123,7 +121,7 @@ during the propagation is described** :ref:`here <rotation_during_propagation>`.
 Outside of the propagation, these quantities can be obtained
 directly from the :class:`~tudatpy.numerical_simulation.environment.RotationalEphemeris` class, which is retrieved from a ``Body`` object using the
 :attr:`~tudatpy.numerical_simulation.environment.Body.rotation_model`. Below, an example is shown on how to extract rotational properties
-for the Earth outside of a propagation (assuming a ``SystemOfBodies`` object, named ``bodies`` has been created)
+for the Earth outside of a propagation (assuming a ``SystemOfBodies`` object, named ``bodies`` has been created):
 
 .. code-block:: python
 
@@ -160,7 +158,7 @@ performs the rotation with the rotation matrix and its derivative:
 The full list of functions to extract rotational quantities from a rotational model can be found under
 :class:`~tudatpy.numerical_simulation.environment.RotationalEphemeris`. Depending on the selected rotation model,
 additional intermediate frames (in addition to the inertial to/from body-fixed rotation) may be available. One example is the
-high-accuracy rotation model, which is discussed in some more detail :ref:`below <gcrs_itrs_frames>`
+high-accuracy rotation model, which is discussed in some more detail :ref:`below <gcrs_itrs_frames>`.
 
 For certain applications, a used must specify the *identifier* of a body-fixed frame in Tudat. This name can be retrieved using
 :attr:`~tudatpy.numerical_simulation.environment.RotationalEphemeris.body_fixed_frame_name`.
@@ -183,7 +181,7 @@ This functionality is implemented as a rotation model, defined using the
 which will in most cases be created during the :ref:`setup of the environment <creation_celestial_body_settings>`
 (and, typically, assigned to the body object representing Earth).
 
-When this rotation model is assigned to Earth, it can be extraced as an object of type :func:`~tudatpy.numerical_simulation.environment.GcrsToItrsRotationModel`
+When this rotation model is assigned to Earth, it can be extraced as an object of type :func:`~tudatpy.numerical_simulation.environment.GcrsToItrsRotationModel`:
 
 .. code-block:: python
 
@@ -245,8 +243,8 @@ To represent the state of a body orbiting a central body, it can often be conven
 vector w.r.t. this central body, and another axis perpendicular to its instantaneous orbital plane.
 For this purpose, the following frames and rotation functions are defined:
 
-* TNW frame. See :func:`~tudatpy.astro.frame_conversion.inertial_to_tnw_rotation_matrix` and :func:`~tudatpy.astro.frame_conversion.tnw_to_inertial_rotation_matrix` for usage and definition
-* RSW frame See :func:`~tudatpy.astro.frame_conversion.inertial_to_rsw_rotation_matrix` and :func:`~tudatpy.astro.frame_conversion.rsw_to_inertial_rotation_matrix` for usage and definition
+* TNW frame: See :func:`~tudatpy.astro.frame_conversion.inertial_to_tnw_rotation_matrix` and :func:`~tudatpy.astro.frame_conversion.tnw_to_inertial_rotation_matrix` for usage and definition.
+* RSW frame: See :func:`~tudatpy.astro.frame_conversion.inertial_to_rsw_rotation_matrix` and :func:`~tudatpy.astro.frame_conversion.rsw_to_inertial_rotation_matrix` for usage and definition.
 
 The input to both functions is the current state of a body w.r.t. a central body, expressed in an inertial frame. For these
 specific functions, it is *not relevant* which specific inertial frame this is. Note that, even though the RSW and TNW frames that are associated
@@ -255,18 +253,18 @@ TNW and RSW frame. As such a given TNW and RSW frame are considered to be inerti
 
 .. _spice_frames:
 
-Spice-defined frames
+SPICE-defined frames
 --------------------
 
-The :ref:`default rotation models <default_rotation_models>` in Tudat make extensive use of the Spice toolbox.
-A user may directly access the functionality of extracting rotations in Spice. For any frame identifiers for which Spice kernels are loaded, the function
+The :ref:`default rotation models <default_rotation_models>` in Tudat make extensive use of the SPICE toolbox.
+A user may directly access the functionality of extracting rotations in SPICE. For any frame identifiers for which SPICE kernels are loaded, the function
 :func:`~tudatpy.interface.spice.compute_rotation_matrix_derivative_between_frames` may be used to determine the rotation matrix between them.
-The derivative of the rotation matrix may be determined from :func:`~compute_rotation_matrix_derivative_between_frames`.
+The derivative of the rotation matrix may be determined from :func:`~tudatpy.interface.spice.compute_rotation_matrix_derivative_between_frames`.
 
-Similarly, a rotation model may be created and assigned to a body that automatically extracts the rotation from Spice, using the
+Similarly, a rotation model may be created and assigned to a body that automatically extracts the rotation from SPICE, using the
 :func:`~tudatpy.numerical_simulation.environment_setup.rotation_model.spice` rotation mode setting (as is done by default for most bodies).
 
-The typical body-fixed frames for solar system bodies are denoted in Spice, as ``IAU_XXXX`` for body ``XXXX``.
+The typical body-fixed frames for solar system bodies are denoted in SPICE as ``IAU_XXXX`` for body ``XXXX``.
 For instance, the default body-fixed frame of Mars is denoted ``IAU_Mars``.
 
 .. _predefined_orientations:
@@ -274,7 +272,7 @@ For instance, the default body-fixed frame of Mars is denoted ``IAU_Mars``.
 Predefined inertial frames
 --------------------------
 
-Through Spice, the following two inertial reference frame orientations are defined by definition:
+Through SPICE, the following two inertial reference frame orientations are defined by definition:
 
 * ``J2000``: Right-handed inertial frame which has :math:`x`-axis towards vernal equinox, and the :math:`z`-axis aligned
   with Earth’s rotation axis as it was at the J2000 epoch. We stress that this frame is inertial, and its
@@ -284,7 +282,7 @@ Through Spice, the following two inertial reference frame orientations are defin
 * ``ECLIPJ2000``: Right-handed inertial frame which has :math:`x`-axis towards vernal equinox, and the :math:`z`-axis
   perpendicular to the ecliptic, at the J2000 epoch.
 
-The J2000 and ECLIPJ2000 frame names can be used for the base or target frames in any of the :ref:`spice rotation functions<spice_frames>`).
+The J2000 and ECLIPJ2000 frame names can be used for the base or target frames in any of the :ref:`SPICE rotation functions<spice_frames>`.
 
 .. _topocentric_frames:
 
@@ -323,7 +321,10 @@ A number of other frames are defined in Tudat, which can be used either during o
 Element Types
 ======================
 
-**Translational** Depending on your application, you will be using any of a number of translational state (position and velocity) representations.
+Translational
+-------------
+
+Depending on your application, you will be using any of a number of translational state (position and velocity) representations.
 In Tudat, conversions involving the following state representations are available:
 
 - Cartesian elements.
@@ -341,23 +342,14 @@ TODO: introduce element index enums
 Note that most, but not all, of these types of elements can also be used for the definition of a
 :ref:`translational state propagator <processed_propagated_states>`,
 where these elements are numerically propagated (instead of the typical Cartesian elements of the Cowell propagator). By definition,
-each element set that can be propagated has conversion functions available in Tudat, but not necesarilly vice versa.
-
-**Rotational** In case you are also working with rotational motion, in Tudat the following representations for attitude/orientation are available:
-
-- Quaternions.
-- Modified Rodrigues parameters.
-- Exponential map.
-
-Transformation between these elements is done by passing through quaternions first (TODO: include link to rotational state propagation).
-For rotational dynamics, the derivative can be expressed as either angular velocity, or time-derivative of the rotation matrix (see :ref:`above <frame_orientations>`)
+each element set that can be propagated has conversion functions available in Tudat, but not necessarily vice versa.
 
 Kepler elements
----------------
+^^^^^^^^^^^^^^^
 
 The Kepler elements are the standard orbital elements used in classical celestial mechanics, and are represented as a size 6 vector in Tudat.
 The meaning of each of the six entries is given in the `API docs <https://py.api.tudat.space/en/latest/element_conversion.html#notes>`_.
-In this list you can see something peculiar: both the Semi-major Axis index and Semi-latus Rectum index are defined as index 0.
+In this list you can see something peculiar: both the semi-major axis index and semi-latus rectum index are defined as index 0.
 The latter option is only applicable when the orbit is parabolic (when the eccentricity is 1.0). That is, if the orbit is parabolic,
 element 0 does not represent the semi-major axis (as it is not defined) but the semi-latus rectum.
 Converting to/from Cartesian state is done using the :func:`~tudatpy.astro.element_conversion.cartesian_to_keplerian` and
@@ -381,26 +373,26 @@ with the Earth as frame origin, the ``keplerian_state`` will also be defined w.r
 As a result, the inclination (for example) will be measured w.r.t. the x-y plane of the `ECLIPJ2000`  frame, **not** w.r.t. the Earth's equator.
 
 .. note::
-    A Keplerian state cannot be computed w.r.t. the Solar System Barycenter (SSB), as it does not possess a gravitational parameter/
+   A Keplerian state cannot be computed w.r.t. the Solar System Barycenter (SSB), as it does not possess a gravitational parameter.
 
 In the definition of the state elements, you will notice that element 5 is the *true* anomaly, not the *eccentric* or
 *mean* anomaly. Tudat also contains functions to convert to these alternative anomalies. The various available functions
-are found in our `API docs <https://py.api.tudat.space/en/latest/element_conversion.html>`
+are found in our `API docs <https://py.api.tudat.space/en/latest/element_conversion.html>`_.
 
 As an example, converting from true to eccentric anomaly is done as follows:
 
 .. code-block:: python
 
-        true_anomaly = ...
-        eccentricity = ...
-        eccentric_anomaly = conversion.true_anomaly_to_eccentric_anomaly( true_anomaly, eccentricity )
+	true_anomaly = ...
+	eccentricity = ...
+	eccentric_anomaly = conversion.true_anomaly_to_eccentric_anomaly( true_anomaly, eccentricity )
 
 or directly from the orbital elements:
 
 .. code-block:: python
 
-        keplerian_state = ...
-        eccentric_anomaly = conversion.true_anomaly_to_eccentric_anomaly( keplerian_state( true_anomaly_index ), keplerian_state( eccentricity_index ) )
+	keplerian_state = ...
+	eccentric_anomaly = conversion.true_anomaly_to_eccentric_anomaly( keplerian_state( true_anomaly_index ), keplerian_state( eccentricity_index ) )
 
 
 Note that this function automatically identifies whether the orbit is elliptical or hyperbolic, and computes the associated eccentric anomaly.
@@ -408,244 +400,258 @@ Similarly, Tudat contains functions to convert from eccentric to mean anomaly (a
 
 .. code-block:: python
 
-        true_anomaly = ...
-        eccentricity = ...
+	true_anomaly = ...
+	eccentricity = ...
 
-        eccentric_anomaly = conversion.true_anomaly_to_eccentric_anomaly( true_anomaly, eccentricity )
-        mean_anomaly = conversion.eccentric_anomaly_to_mean_anomaly( eccentric_anomaly, eccentricity )
+	eccentric_anomaly = conversion.true_anomaly_to_eccentric_anomaly( true_anomaly, eccentricity )
+	mean_anomaly = conversion.eccentric_anomaly_to_mean_anomaly( eccentric_anomaly, eccentricity )
 
 The conversion from mean to eccentric anomaly involves the solution of an implicit algebraic equation (Kepler's equation), for which a root finder is used.
 Root finders are discussed in more detail here (TODO: insert link). Tudat has a default root finder, and default selection for
-initial guess of the foot-finding implemented see :func:`~tudatpy.astro.element_conversion.mean_to_eccentric_anomaly`
+initial guess of the root-finding implemented see :func:`~tudatpy.astro.element_conversion.mean_to_eccentric_anomaly`.
 However, in some cases you may want to specify your own initial guess for the eccentric anomaly, and/or your own root finder.
 You can do this as follows:
 
 .. code-block:: python
 
-        mean_anomaly = ...
-        eccentricity = ...
-        initial_guess = ...
-        root_finder = ...
+	mean_anomaly = ...
+	eccentricity = ...
+	initial_guess = ...
+	root_finder = ...
 
-        eccentric_anomaly = conversion.mean_anomaly_to_eccentric_anomaly(
-            eccentricity = eccentricity,
-            mean_anomaly = mean_anomaly,
-            use_default_initial_guess = False, #Optional; set to False to use optional user-defined initial guess
-            non_default_initial_guess = initial_guess, #optional
-            root_finder = root_finder #optional
-            )
+	eccentric_anomaly = conversion.mean_anomaly_to_eccentric_anomaly(
+		eccentricity = eccentricity,
+		mean_anomaly = mean_anomaly,
+		use_default_initial_guess = False, #Optional; set to False to use optional user-defined initial guess
+		non_default_initial_guess = initial_guess, #optional
+		root_finder = root_finder #optional
+		)
 
 The above function can be used with only the eccentricity and mean anomaly inputs, in which case the defaults are used for the
-initial guess and root finder.s
+initial guess and root finders.
+
+Spherical-orbital Elements
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The spherical elements are typically used to denote the conditions in atmospheric flight. In most applications, they will be used to denote the state in a body-fixed frame. The details of the physical meaning of the elements is discussed here. The element indices in Tudat are the following:
+
+.. list-table:: Spherical-orbital Elements Indices.
+	:widths: 50 50
+	:header-rows: 1
+
+	* - Column Indices
+	  - Spherical-orbital Elements
+	* - 0
+	  - Radius
+	* - 1
+	  - Latitude
+	* - 2
+	  - Longitude
+	* - 3
+	  - Speed
+	* - 4
+	  - Flight Path Angle
+	* - 5
+	  - Heading Angle
+
+The spherical elements consist of 6 entries, with no additional information required for the conversion to/from Cartesian elements. The conversion from Cartesian to spherical elements is performed as:
+
+.. code-block:: python
+
+	cartesian_state = ...
+
+	spherical_state = conversion.cartesian_to_spherical( cartesian_state )
+
+Similarly, the inverse operation is done as:
+
+.. code-block:: python
+
+	spherical_state = ...
+
+	cartesian_state = conversion.spherical_to_cartesian( spherical_state )
+
+
+Modified Equinoctial Elements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The modified equinoctial elements are typically used for orbits with eccentricities near 0 or 1 and/or inclinations near 0 or :math:`\pi`. The element indices in Tudat are the following:
+
+.. list-table:: Modified Equinoctial Elements Indices.
+	:widths: 50 50
+	:header-rows: 1
+
+	* - Column Indices
+	  - Modified Equinoctial Elements
+	* - 0
+	  - Semi-parameter
+	* - 1
+	  - f-element
+	* - 2
+	  - g-element
+	* - 3
+	  - h-element
+	* - 4
+	  - k-element
+	* - 5
+	  - True Longitude
+
+The modified equinoctial elements consists of 6 elements. The conversion to/from Cartesian elements requires the gravitational parameter of the body w.r.t. which the Modified Equinoctial elements are defined. The conversion from Cartesian elements is done using the :func:`~tudatpy.astro.element_conversion.cartesian_to_mee` function:
+
+.. code-block:: python
+
+	cartesian_state = ...
+	central_body = ...
+	central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
+
+	modified_equinoctial_state = conversion.cartesian_to_mee( cartesian_state, central_body_gravitational_parameter )
+
+The :func:`~tudatpy.astro.element_conversion.cartesian_to_mee` function computes the singularity-flipping element :math:`I` automatically using the :func:`~tudatpy.astro.element_conversion.flip_mee_singularity` function. Alternatively, the singularity-flipping element can be provided manually with the :func:`~tudatpy.astro.element_conversion.cartesian_to_mee_manual_singularity` function. 
+
+Similarly, the inverse operation is done as:
+
+.. code-block:: python
+
+	modified_equinoctial_state = ...
+	central_body = ...
+	central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
+
+	cartesian_state = conversion.mee_to_cartesian( modified_equinoctial_state, central_body_gravitational_parameter )
+
+
+Unified State Model Elements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Three different versions of the Unified State Model are present in Tudat. They differ based on the coordinates chosen to represent the rotation from local orbital to inertial frame, which can be expressed in quaternions (USM7), modified Rodrigues parameters (USM6) or exponential map (USMEM). The element indices are the following:
+
+.. list-table:: Unified State Model indices with quaternions (USM7), modified Rodrigues parameters (USM6) or exponential map (USMEM).
+	:widths: 25 25 25 25
+	:header-rows: 1
+
+	* - Column Indices
+	  - USM7
+	  - USM6
+	  - USMEM
+	* - 0
+	  - C Hodograph
+	  - C Hodograph
+	  - C Hodograph
+	* - 1
+	  - Rf1 Hodograph
+	  - Rf1 Hodograph
+	  - Rf1 Hodograph
+	* - 2
+	  - Rf2 Hodograph
+	  - Rf2 Hodograph
+	  - Rf2 Hodograph
+	* - 3
+	  - :math:`\eta`
+	  - :math:`\sigma_1`
+	  - e1
+	* - 4
+	  - :math:`\epsilon_1`
+	  - :math:`\sigma_2`
+	  - e2
+	* - 5
+	  - :math:`\epsilon_2`
+	  - :math:`\sigma_3`
+	  - e3
+	* - 6
+	  - :math:`\epsilon_3`
+	  - Shadow flag
+	  - Shadow flag
+
+Regardless of the rotational coordinates chosen, the Unified State Model elements consists of 7 elements. For each Unified State Model representation, conversion to and from Keplerian and Cartesian coordinates is implemented. As an example, the conversion from Keplerian elements for the USM7 elements is shown here:
+
+.. code-block:: python
+
+	keplerian_elements = ...
+	central_body = ...
+	central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
+
+	unified_state_model_elements = conversion.keplerian_to_unified_state_model( keplerian_elements, central_body_gravitational_parameter )
+
+Similarly, the inverse operation is done as:
+
+.. code-block:: python
+
+	unified_state_model_elements = ...
+	central_body = ...
+	central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
+
+	keplerian_elements = conversion.unified_state_model_to_keplerian( keplerian_elements, central_body_gravitational_parameter )
 
 
 
-.. class:: Spherical-orbital Elements
+Rotational
+----------
 
-	The spherical elements are typically used to denote the conditions in atmospheric flight. In most applications, they will be used to denote the state in a body-fixed frame. The details of the physical meaning of the elements is discussed here. The element indices in Tudat are the following:
+In case you are also working with rotational motion, in Tudat the following representations for attitude/orientation are available:
 
-	.. list-table:: Spherical-orbital Elements Indices.
-		 :widths: 50 50
-		 :header-rows: 1
+- Quaternions.
+- Modified Rodrigues parameters.
+- Exponential map.
 
-		 * - Column Indices
-		   - Spherical-orbital Elements
-		 * - 0
-		   - Radius
-		 * - 1
-		   - Latitude
-		 * - 2
-		   - Longitude
-		 * - 3
-		   - Speed
-		 * - 4
-		   - Flight Path Angle
-		 * - 5
-		   - Heading Angle
-	
-	The spherical elements consist of 6 entries, with no additional information required for the conversion to/from Cartesian elements. The conversion from Cartesian to spherical elements is performed as:
+Transformation between these elements is done by passing through quaternions first (TODO: include link to rotational state propagation).
+For rotational dynamics, the derivative can be expressed as either angular velocity, or time-derivative of the rotation matrix (see :ref:`above <frame_orientations>`).
 
-	.. code-block:: python
+Quaternions
+^^^^^^^^^^^
 
-		cartesian_state = ...
+As mentioned at the beginning of this chapter, quaternions are the default attitude representation in Tudat. Depending on the location in the Tudat framework, you will find a quaternion element expressed as either of the two types below:
 
-		spherical_state = conversion.cartesian_to_spherical( cartesian_state )
+**TODO-Dominic**
 
-	Similarly, the inverse operation is done as:
+Modified Rodrigues Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-	.. code-block:: python
+One of the other two supported attitude representations is the modified Rodrigues parameters (MRPs). The indices for MRPs are defined as follows:
 
-		spherical_state = ...
+.. list-table:: Modified Rodrigues Parameters Indices.
+   :widths: 50 50
+   :header-rows: 1
 
-		cartesian_state = conversion.spherical_to_cartesian( spherical_state )
-
-.. class:: Modified Equinoctial Elements
-	
-	The modified equinoctial elements are typically used for orbits with eccentricities near 0 or 1 and/or inclinations near 0 or :math:`\pi`. The element indices in Tudat are the following:
-
-	.. list-table:: Modified Equinoctial Elements Indices.
-		 :widths: 50 50
-		 :header-rows: 1
-
-		 * - Column Indices
-		   - Modified Equinoctial Elements
-		 * - 0
-		   - Semi-parameter
-		 * - 1
-		   - f-element
-		 * - 2
-		   - g-element
-		 * - 3
-		   - h-element
-		 * - 4
-		   - k-element
-		 * - 5
-		   - True Longitude
-
-	The modified equinoctial elements consists of 6 elements. The conversion to/from Cartesian elements requires the gravitation parameter of the body w.r.t. which the Modified Equinoctial elements are defined. Furthermore, a ``bool`` is used to indicate whether the singularity of this element set occurs for inclinations of 0 or :math:`\pi`. The conversion from Cartesian elements is done as:
-
-	.. code-block:: python
-
-		cartesian_state = ...
-		central_body = ...
-		central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
-
-		modified_equinoctial_state = conversion.cartesian_to_modified_equinoctial( cartesian_state, central_body_gravitational_parameter, flip_singularity_to_zero_inclination )
-
-	.. note:: 
-		The input ``flip_singularity_to_zero_inlination`` is optional for this conversion. If left empty, an overloaded function will determine whether this value is true or false based on the inclination of the orbit.
-
-	Similarly, the inverse operation is done as:
-
-	.. code-block:: python
-
-		modified_equinoctial_state = ...
-		central_body = ...
-		central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
-
-		cartesian_state = conversion.modified_equinoctial_to_cartesian( modified_equinoctial_state, central_body_gravitational_parameter, flip_singularity_to_zero_inclination )
-		
+   * - Column Indices
+     - Modified Rodrigues Parameter
+   * - 0
+     - :math:`\sigma` 1
+   * - 1
+     - :math:`\sigma` 2
+   * - 2
+     - :math:`\sigma` 3
+   * - 3
+     - Shadow flag
 
 
-.. class:: Unified State Model Elements
+Transformation to and from quaternions is achieved with the functions ``conversion.modified_rodrigues_parameters_to_quaternions`` and ``conversion.quaterns_to_modified_rodrigues_parameter_elements``, respectively, where the only input is the attitude element (in vector format).
 
-	Three different versions of the Unified State Model are present in Tudat. They differ based on the coordinates chosen to represent the rotation from local orbital to inertial frame, which can be expressed in quaternions (USM7), modified Rodrigues parameters (USM6) or exponential map (USMEM). The element indices are the following:
+.. note::
 
-	.. list-table:: Unified State Model indices with quaternions (USM7), modified Rodrigues parameters (USM6) or exponential map (USMEM).
-		 :widths: 25 25 25 25
-		 :header-rows: 1
-
-		 * - Column Indices
-		   - USM7
-		   - USM6
-		   - USMEM
-		 * - 0
-		   - C Hodograph
-		   - C Hodograph
-		   - C Hodograph
-		 * - 1
-		   - Rf1 Hodograph
-		   - Rf1 Hodograph
-		   - Rf1 Hodograph
-		 * - 2
-		   - Rf2 Hodograph
-		   - Rf2 Hodograph
-		   - Rf2 Hodograph
-		 * - 3
-		   - :math:`\eta`
-		   - :math:`\sigma` 1
-		   - e1
-		 * - 4
-		   - :math:`\epsilon` 1
-		   - :math:`\sigma` 2
-		   - e2
-		 * - 5
-		   - :math:`\epsilon` 2
-		   - :math:`\sigma` 3
-		   - e3
-		 * - 6
-		   - :math:`\epsilon` 3
-		   - Shadow flag
-		   - Shadow flag
-
-	Regardless of the rotational coordinates chosen, the Unified State Model elements consists of 7 elements. For each Unified State Model representation, conversion to and from Keplerian and Cartesian coordinates is implemented. As an example, the conversion from Keplerian elements for the USM7 elements is shown here:
-
-	.. code-block:: python
-
-		keplerian_elements = ...
-		central_body = ...
-		central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
-
-		unified_state_model_elements = conversion.keplerian_to_unified_state_model( keplerian_elements, central_body_gravitational_parameter )
-
-	Similarly, the inverse operation is done as:
-
-	.. code-block:: python
-
-		unified_state_model_elements = ...
-		central_body = ...
-		central_body_gravitational_parameter = bodies.get( central_body ).gravitational_parameter
-
-		keplerian_elements = conversion.unified_state_model_to_keplerian( keplerian_elements, central_body_gravitational_parameter )
-
-.. class:: Quaternions
-
-	As mentioned at the beginning of this chapter, quaternions are the default attitude representation in Tudat. Depending on the location in the Tudat framework, you will find a quaternion element expressed as either of the two types below:
-
-	**TODO-Dominic**
-
-.. class:: Modified Rodrigues Parameters
-
-	One of the other two supported attitude representations is the modified Rodrigues parameters (MRPs). The indeces for MRPs are defined as follows:
-
-		.. list-table:: Modified Rodrigues Parameters Indices.
-		 :widths: 50 50
-		 :header-rows: 1
-
-		 * - Column Indices
-		   - Modified Rodrigues Parameter
-		 * - 0
-		   - :math:`\sigma` 1
-		 * - 1
-		   - :math:`\sigma` 2
-		 * - 2
-		   - :math:`\sigma` 3
-		 * - 3
-		   - Shadow flag
+	The last index is the flag that triggers the shadow modified Rodrigues parameters (SMRPs). Its use is introduced to avoid the singularity at :math:`\pm 2 \pi` radians. If its value is 0, then the elements are MRPs, whereas if it is 1, then they are SMRPs. The use of SMRPs results in slightly different equations of motion and transformations. The switch between MRPs and SMRPs occurs whenever the magnitude of the rotation represented by the MRP vector is larger than :math:`\pi`.
 
 
-	Transformation to and from quaternions is achieved with the functions ``conversion.modified_rodrigues_parameters_to_quaternions`` and ``conversion.quaterns_to_modified_rodrigues_parameter_elements``, respectively, where the only input is the attitude element (in vector format).
+Exponential Map
+^^^^^^^^^^^^^^^
 
-	.. note::
+The final attitude representations is the exponential map (EM). The indices for EM are defined as follows:
 
-		The last index is the flag that triggers the shadow modifed Rodrigues parameters (SMRPs). Its use is introduced to avoid the singularity at :math:`\pm 2 \pi` radians. If its value is 0, then the elements are MRPs, whereas if it is 1, then they are SMRPs. The use of SMRPs results in slightly different equations of motion and transformations. The switch between MRPs and SMRPs occurs whenever the magnitude of the rotation represented by the MRP vector is larger than :math:`\pi`.
+.. list-table:: Exponential Map Indices.
+	:widths: 50 50
+	:header-rows: 1
 
+	* - Column Indices
+	  - Exponential Map
+	* - 0
+	  - e1
+	* - 1
+	  - e2
+	* - 2
+	  - e3
+	* - 3
+	  - Shadow flag
 
-.. class:: Exponential Map
-
-	The final attitude representations is the exponential map (EM). The indeces for EM are defined as follows:
-
-		.. list-table:: Exponential Map Indices.
-		 :widths: 50 50
-		 :header-rows: 1
-
-		 * - Column Indices
-		   - Exponential Map
-		 * - 0
-		   - e1
-		 * - 1
-		   - e2
-		 * - 2
-		   - e3
-		 * - 3
-		   - Shadow flag
-
-	and transformation to and from quaternions is achieved with the aid of the functions ``conversion.exponential_map_to_quaternions`` and ``conversions.quaternions_to_exponential_map``, respectively. Also for these equations the only input is the attitude element (in vector format).
+and transformation to and from quaternions is achieved with the aid of the functions ``conversion.exponential_map_to_quaternions`` and ``conversions.quaternions_to_exponential_map``, respectively. Also for these equations the only input is the attitude element (in vector format).
 
 
-	.. note:: 
+.. note:: 
 
-		Similarly to MRPs, the exponential map elements also make use of the shadow flag. In this case, this flag signals whether the shadow exponential map (SEM) is in use. This flag is also introduces to avoid the singularity at :math:`\pm 2 \pi` radians, but interestingly, there is no difference between the equations of motion and transformations in terms of EM or SEM. In fact, they are only introduced to make sure that when converting from EM to quaternions, the resulting quaternion sign history is continuous. The switch between EM and SEM occurs whenever the magnitude of the rotation represented by the EM vector is larger than :math:`\pi`.
-
-
-
+	Similarly to MRPs, the exponential map elements also make use of the shadow flag. In this case, this flag signals whether the shadow exponential map (SEM) is in use. This flag is also introduces to avoid the singularity at :math:`\pm 2 \pi` radians, but interestingly, there is no difference between the equations of motion and transformations in terms of EM or SEM. In fact, they are only introduced to make sure that when converting from EM to quaternions, the resulting quaternion sign history is continuous. The switch between EM and SEM occurs whenever the magnitude of the rotation represented by the EM vector is larger than :math:`\pi`.


### PR DESCRIPTION
This PR superseeds #138. No content-wise changes are made, it is just based on the develop branch and should thus include the most recent changes.

# Before Merging
Please verify that the build works correctly before merging, in particular the `Note` box in the `Kepler element` section. In my local build the box does not end as intended after "... as it does not possess a gravitational parameter.", but only once the next section on spherical elements is started, see below. It seems to be an issue on my side, as all boxes (also in other pages which were not modified) show this behavior. This could not be resolved and might be related to my local build environment, see also [this pull request](https://github.com/tudat-team/tudat-developer-docs/pull/27).

![image](https://github.com/tudat-team/tudat-space/assets/105521415/2e18f70e-ab16-4eb3-8f94-5903f2890175)