### PR TITLE
Document contributing to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ The `tudat-space` repository contains the `docs` directory, which hosts all info
 2. `tudat-space/docs/environment.yaml`, which holds information to create the `tudat-docs` environment. This environment is used to build the website locally and on [ReadtheDocs](https://readthedocs.org/projects/tudat-space/).
 3. `tudat-space/.readthedocs.yml` contains the configuration for the online build on [ReadtheDocs](https://readthedocs.org/projects/tudat-space/).
 4. (If the documentation has been built locally): `tudat-space/docs/build`, which contains the local build in `.html` files.
-   
+
+The [examples on the website](https://docs.tudat.space/en/latest/_src_getting_started/examples.html) are integrated using the [tudatpy-examples repository](https://github.com/tudat-team/tudatpy-examples) as a submodule.
+If you would like to add examples or make changes, please contribute in the `tudatpy-examples` repository.
+This repository will be automatically updated from the [Sync tudat-space submodule](https://github.com/tudat-team/tudatpy-examples/actions/workflows/sync-tudat-space.yml) action.
 
 ## How to build the `tudat-space` website locally 
 


### PR DESCRIPTION
This PR adds information in the README on how to contribute to example applications and documents the automatic updating with `tudatpy-examples`, fixing https://github.com/tudat-team/tudatpy-examples/issues/56.