### PR TITLE
Add new examples

### DIFF
--- a/docs/source/_src_getting_started/_src_examples/estimation.rst
+++ b/docs/source/_src_getting_started/_src_examples/estimation.rst
@@ -12,6 +12,7 @@ In the following examples, observations are simulated and then used as input for
 .. nbgallery::
 
   ./tudatpy-examples/estimation/covariance_estimated_parameters.ipynb
+  ./tudatpy-examples/estimation/covariance_propagation_example.ipynb
   ./tudatpy-examples/estimation/full_estimation_example.ipynb
   ./tudatpy-examples/estimation/estimation_dynamical_models.ipynb
   

--- a/docs/source/_src_getting_started/_src_examples/mission_design.rst
+++ b/docs/source/_src_getting_started/_src_examples/mission_design.rst
@@ -12,7 +12,7 @@ The following examples compute the performance (e.g. Delta V, time of flight, et
 
 .. nbgallery::
 
-  ./tudatpy-examples/propagation/mga_trajectories.ipynb
+  ./tudatpy-examples/mission_design/mga_trajectories.ipynb
   ./tudatpy-examples/mission_design/earth_mars_transfer_window.ipynb
   
 .. _trajectory_optimization_examples:

--- a/docs/source/_src_getting_started/_src_examples/propagation.rst
+++ b/docs/source/_src_getting_started/_src_examples/propagation.rst
@@ -13,8 +13,8 @@ The following examples showcase the basic functionality of the Tudat numerical p
 
 
   ./tudatpy-examples/propagation/keplerian_satellite_orbit.ipynb
-  ./tudatpy-examples/propagation/linear_sensitivity_analysis.ipynb
   ./tudatpy-examples/propagation/perturbed_satellite_orbit.ipynb
+  ./tudatpy-examples/propagation/linear_sensitivity_analysis.ipynb
   ./tudatpy-examples/propagation/solar_system_propagation.ipynb
   ./tudatpy-examples/propagation/thrust_between_Earth_Moon.ipynb
 
@@ -27,6 +27,7 @@ Note that an additional related example (in particular on the setup of a custom 
 .. nbgallery::
 
   ./tudatpy-examples/propagation/reentry_trajectory.ipynb
+  ./tudatpy-examples/propagation/two_stage_rocket_ascent.ipynb
   ./tudatpy-examples/propagation/separation_satellites_diff_drag.ipynb
   ./tudatpy-examples/propagation/coupled_translational_rotational_dynamics.ipynb
   ./tudatpy-examples/propagation/impact_manifolds_lpo_cr3bp.ipynb


### PR DESCRIPTION
This PR fixes #150.

Changes made on the tudat-space side:
- Add new examples to website:
  - `covariance_propagation_example.ipynb`
  - `two_stage_rocket_ascent.ipynb`
- Reorder examples

# Before merging
@DominicDirkx Could you create a new build for this PR/branch on read-the-docs? I tested everything locally and it worked, this is more to see if the workflow of manually updating the submodule works as expected in the read-the-docs build. Thank you :)

Please merge this PR first, before merging the corresponding tudatpy-examples PR (https://github.com/tudat-team/tudatpy-examples/pull/71). That way, the automatic sync should take care of the merge commit and update the submodule here correspondingly.