### PR TITLE
Feature: Automatic code links from examples to API reference

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -12,3 +12,4 @@ dependencies:
   - ipython
   - ipykernel
   - pandoc
+  - sphinx-codeautolink

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,3 +1,13 @@
 .wy-nav-content {
     max-width: 1000px !important;
 }
+
+.sphinx-codeautolink-a {
+    border-bottom-color: rgb(0, 0, 0);
+    border-bottom-style: dotted;
+    border-bottom-width: 1px;
+}
+
+.sphinx-codeautolink-a:hover {
+    color: rgb(255, 139, 139);
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx_gallery.load_style',  # to show notebooks as galleries
               'sphinx_rtd_theme', # theme
               'sphinx_copybutton', # copy button in code blocks
+              "sphinx_codeautolink",
               ]
 
 # Specifying thumbnails according to images in _static folder

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,7 +219,8 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 # test / view content of inventory file at url via $ python -msphinx.ext.intersphinx <url>
 intersphinx_mapping = {'tudatpy': ('https://py.api.tudat.space/en/latest/', None),
-                       'python': ('https://docs.python.org/3/', None)}
+                       'python': ('https://docs.python.org/3/', None),
+                       "numpy": ("https://numpy.org/doc/stable/", None),}
 
 intersphinx_disabled_reftypes = []
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -222,3 +222,6 @@ intersphinx_mapping = {'tudatpy': ('https://py.api.tudat.space/en/latest/', None
                        'python': ('https://docs.python.org/3/', None)}
 
 intersphinx_disabled_reftypes = []
+
+# -- Options for sphinx_codeautolink -------------------------------------------
+codeautolink_concat_default = True


### PR DESCRIPTION
This PR adds automatic links from code snippets/examples to the API reference. For the rationale behind choosing `sphinx-codeautolink` instead of `sphinx-gallery`, see #157.